### PR TITLE
Release 0.6.0.0 (develop)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,11 @@
 # Revision history for network-arbitrary
 
+## 0.6.0.0  -- 2020-04-11
+
+* Update project structure.
+* Migration to ghc 8.8
+* Update travis.yml with haskell-ci
+
 ## 0.5.0.0  -- 2019-12-13
 
 * Bump upper bounds of dependencies.

--- a/default.nix
+++ b/default.nix
@@ -4,7 +4,7 @@
 }:
 mkDerivation {
   pname = "network-arbitrary";
-  version = "0.5.0.0";
+  version = "0.6.0.0";
   src = ./.;
   libraryHaskellDepends = [
     base bytestring http-media http-types network-uri QuickCheck

--- a/network-arbitrary.cabal
+++ b/network-arbitrary.cabal
@@ -1,5 +1,5 @@
 name:                network-arbitrary
-version:             0.5.0.0
+version:             0.6.0.0
 
 license:             MIT
 license-file:        LICENSE


### PR DESCRIPTION
* Update project structure.
* Migration to ghc 8.8
* Update travis.yml with haskell-ci