### PR TITLE
Configure Renovate with config:best-practices preset

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,6 +14,11 @@ repos:
       - id: destroyed-symlinks
       - id: end-of-file-fixer
       - id: trailing-whitespace
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 43.150.0
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict, --no-global]
   - repo: local
     hooks:
       - id: haskell-ci regenerate

--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,10 @@
   "baseBranchPatterns": ["master"],
   "reviewers": ["alunduil"],
   "pre-commit": { "enabled": true },
+  "minimumReleaseAge": "3 days",
+  "internalChecksFilter": "strict",
+  "vulnerabilityAlerts": { "minimumReleaseAge": "0 days" },
+  "osvVulnerabilityAlerts": true,
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices"],
+  "baseBranchPatterns": ["master"],
+  "reviewers": ["alunduil"],
+  "pre-commit": { "enabled": true },
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["patch"],
+      "automerge": true
+    },
+    {
+      "matchPackageNames": ["hspec", "hspec-discover", "QuickCheck"],
+      "groupName": "haskell test stack"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adopts `config:best-practices` for Renovate with supply-chain hardening, replacing the minimal `config:recommended` onboarding config from PR #70. Pre-commit hook versions track upstream automatically, patch updates auto-merge after a 3-day bake, and CVE fixes bypass the bake.

## Gotchas

- Supersedes #70 — close that PR after this merges.
- `automerge: true` on patch updates relies on platform automerge; branch protection on `master` must permit it for the rule to take effect. The 3-day `minimumReleaseAge` runs before automerge, so a malicious patch publish has time to be yanked before reaching master.
- `hspec`, `hspec-discover`, and `QuickCheck` are grouped into one PR; expect Renovate's first run after merge to bundle pending bumps for those.
- The 28 Haskell-CI failures on this PR are GitHub Actions runner-queue timeouts ("exceeded the maximum execution time while awaiting a runner for 24h0m0s"), not test failures — the diff is config-only and can't affect Haskell builds.

## Verification

- Ran `renovate-config-validator --strict --no-global` via pre-commit on the final config — passed.
- Validated `renovate.json` parses (`python3 -m json.tool`).

Closes #72.