### PR TITLE
Add CLAUDE.md with tooling inventory and scope discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# network-arbitrary — Claude guide
+
+QuickCheck `Arbitrary` instances for network types. `stability: stable`,
+PVP-versioned (current `1.0.0.1`), `cabal-version: 3.0`.
+
+## Tooling inventory
+
+Prefer these over `curl`, manual API calls, or first-principles scripts.
+
+- Build / test: `cabal build`, `cabal test`. HLS via `hie.yaml` (cabal cradle).
+- Lint / format: `pre-commit` (`.pre-commit-config.yaml`) runs
+  `haskell-ci regenerate` (haskell-ci-0.18.1), hlint-3.6.1, `cabal check`,
+  ormolu-0.7.3.0, cabal-fmt-0.1.9. Versions are pinned and Renovate-managed —
+  don't substitute or upgrade them in passing.
+- Dev environment: `.devcontainer/`.
+- Supported GHC (`tested-with`): 9.4, 9.6, 9.8, 9.10.
+
+## Scope discipline
+
+A `stable` API under PVP with three open milestones (1.0.0.2, 1.0.0.3,
+2.0.0.0) makes incidental export changes costly, and `network-uri-json`
+uses this repo as its modernization template, so patterns set here spread.
+
+- Before opening a PR, verify scope doesn't overlap linked or sibling
+  issues; if uncertain, ask.
+- An issue blocked by unshipped prerequisites: propose deferral with
+  `blocked-by` edges, don't write premature code.
+- Revert incidental out-of-scope edits before requesting review.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,25 +1,24 @@
 # network-arbitrary — Claude guide
 
 QuickCheck `Arbitrary` instances for network types. `stability: stable`,
-PVP-versioned (current `1.0.0.1`), `cabal-version: 3.0`.
+PVP-versioned.
 
 ## Tooling inventory
 
 Prefer these over `curl`, manual API calls, or first-principles scripts.
 
-- Build / test: `cabal build`, `cabal test`. HLS via `hie.yaml` (cabal cradle).
-- Lint / format: `pre-commit` (`.pre-commit-config.yaml`) runs
-  `haskell-ci regenerate` (haskell-ci-0.18.1), hlint-3.6.1, `cabal check`,
-  ormolu-0.7.3.0, cabal-fmt-0.1.9. Versions are pinned and Renovate-managed —
-  don't substitute or upgrade them in passing.
+- Build / test: `cabal build`, `cabal test`. HLS via `hie.yaml`.
+- Lint / format: `pre-commit run --all-files`. Hook versions in
+  `.pre-commit-config.yaml` are pinned and Renovate-managed — don't
+  substitute or upgrade them in passing.
 - Dev environment: `.devcontainer/`.
-- Supported GHC (`tested-with`): 9.4, 9.6, 9.8, 9.10.
+- Supported GHC: `tested-with` in `network-arbitrary.cabal`.
 
 ## Scope discipline
 
-A `stable` API under PVP with three open milestones (1.0.0.2, 1.0.0.3,
-2.0.0.0) makes incidental export changes costly, and `network-uri-json`
-uses this repo as its modernization template, so patterns set here spread.
+A `stable` API under PVP makes incidental export changes costly, and
+`network-uri-json` uses this repo as its modernization template, so
+patterns set here spread.
 
 - Before opening a PR, verify scope doesn't overlap linked or sibling
   issues; if uncertain, ask.


### PR DESCRIPTION
## Summary

Creates the repo's first `CLAUDE.md` (issue #88). Two sections, both calibrated to this repo rather than generic best-practice filler:

- **Tooling inventory** — points Claude at `cabal build`/`cabal test`, `pre-commit`, `.devcontainer/`, and HLS, so the first move on a task is discovery instead of reaching for `curl` or ad-hoc scripts.
- **Scope discipline** — records why incidental export changes are costly here (stable API, PVP, this repo as `network-uri-json`'s template) and the guardrails that follow.

## Gotchas

- The guide references code-coupled facts rather than duplicating them. Version, supported-GHC list, pinned tool versions, and milestone numbers all live in `network-arbitrary.cabal`, `.pre-commit-config.yaml`, and the milestone set — the guide points there so it stays evergreen and doesn't rot as those change (notably as Renovate bumps the pinned hooks).

## Verification

- `pre-commit run --files CLAUDE.md` — all applicable hooks pass (end-of-file, trailing-whitespace, large-files); Haskell hooks correctly skip a markdown file.

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)